### PR TITLE
Replace reference to obsolete package (fix #1)

### DIFF
--- a/misc/preamble.tex
+++ b/misc/preamble.tex
@@ -106,7 +106,7 @@
 \usepackage[ruled, vlined, linesnumbered,algochapter,algo2e]{algorithm2e}
 
 % Format page foot and header
-\usepackage{scrpage2}
+\usepackage{scrlayer-scrpage}
 \clearscrheadings
 \clearscrheadfoot
 \automark[section]{chapter}


### PR DESCRIPTION
Fixes https://github.com/RUB-NDS/exposee_layout/issues/1

[scrpage2](https://www.ctan.org/pkg/scrpage2) doesn't seem to be included in the newer releases of texlive and Miktex. [scrlayer-scrpage](https://www.ctan.org/pkg/scrlayer-scrpage) is the successor to this package and backwards compatible, so using it shouldn't be an issue.