### PR TITLE
Make bold text work again (preamble.tex)

### DIFF
--- a/misc/preamble.tex
+++ b/misc/preamble.tex
@@ -122,7 +122,7 @@
 \definecolor{linkred}{RGB}{165,0,33}
 \renewcommand\sfdefault{phv}
 % \renewcommand\mddefault{mc}  %Bugfixing emph and textbf
-\renewcommand\bfdefault{bc}
+% \renewcommand\bfdefault{bc}  %Bugfix, make textbf actually work
 \setganttlinklabel{s-s}{START-TO-START}
 \setganttlinklabel{f-s}{FINISH-TO-START}
 \setganttlinklabel{f-f}{FINISH-TO-FINISH}


### PR DESCRIPTION
Without this change, when using the provided setup, it is not possible to write bold text. The bugfix in the line above is insufficient.